### PR TITLE
Change SP2 to SP3 in ISO names.

### DIFF
--- a/Work-In-Progress.md
+++ b/Work-In-Progress.md
@@ -7,7 +7,7 @@ New Data format for Stacki
 			"pallet": [
 				{"name" : "tdc-infrastructure", "version": "1.0", "release":"sles11", "url":"https://", "box" : ["default", "sles12"]},
 				{"name" : "netapp", "version": "1.0", "release":"sles12", "box": []},
-				{"name" : "kubernetes", "version": "1.0", "release":"sles12sp2", "box": []}
+				{"name" : "kubernetes", "version": "1.0", "release":"sles12sp3", "box": []}
 			],
 			"cart" : [
 				{"name": "mycart-12.2", "url":"https://", "box":["default", "sles12"]},

--- a/wiki/Developer/Building-From-Source.md
+++ b/wiki/Developer/Building-From-Source.md
@@ -46,13 +46,13 @@ Start with a fresh install of [CentOS 7.6](http://archive.kernel.org/centos-vaul
 
 #### SLES
 
-##### 12SP2
+##### 12SP3
 
 Start with a fresh install of SLES 12, using the default desktop/workstation "system role".  If you do not have access to the remote SLES zypper repositories, you need to add the install ISO and the first SDK ISO as repos.
 
 ```
-zypper ar iso:/?iso=/export/SLE-12-SP2-Server-DVD-x86_64-GM-DVD1.iso install_dvd
-zypper ar iso:/?iso=/export/SLE-12-SP2-SDK-DVD-x86_64-GM-DVD1.iso sdk_dvd
+zypper ar iso:/?iso=/export/SLE-12-SP3-Server-DVD-x86_64-GM-DVD1.iso install_dvd
+zypper ar iso:/?iso=/export/SLE-12-SP3-SDK-DVD-x86_64-GM-DVD1.iso sdk_dvd
 ```
 
 ##### 11SP3

--- a/wiki/Development.md
+++ b/wiki/Development.md
@@ -23,7 +23,7 @@ We need a real consensus on this, but right now the rule is when you
 drop into a piece of code try to copy the existing style. For new code
 just keep it readable. Eventually someone will get bored and write up
 a style guide for Stacki, we will fight about it for a week or so and
-loose interest and we will be back to where we are now. All of this
+lose interest and we will be back to where we are now. All of this
 has happened before, and all of this will happen again.
 
 There is a `.flake8` (think `pep8` with more stuff) in the Stacki


### PR DESCRIPTION
One can "lose weight" or "loose[n] your belt"
but "loose weight" just jiggles all over the place.